### PR TITLE
Added CI tools, allow to use without meta-fields

### DIFF
--- a/.github/linting.yaml
+++ b/.github/linting.yaml
@@ -1,0 +1,25 @@
+name: CI
+on:
+    pull_request: null
+    push:
+        branches:
+            - master
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['7.4', '8.0', '8.1']
+
+        name: Linting - PHP ${{ matrix.php }}
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: intl, gd, zip
+            -   run: composer install --no-progress
+            -   run: composer validate --strict --no-check-version
+            -   run: composer codestyle-check
+            -   run: composer phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .disabled
 /vendor/
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,172 @@
+<?php
+
+$fileHeaderComment = <<<COMMENT
+This file is part of the Kimai time-tracking app.
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+COMMENT;
+
+$fixer = new PhpCsFixer\Config();
+$fixer
+    ->setRiskyAllowed(true)
+    ->setRules([
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'blank_line_after_namespace' => true,
+        'braces' => true,
+        'class_definition' => true,
+        'elseif' => true,
+        'function_declaration' => true,
+        'indentation_type' => true,
+        'line_ending' => true,
+        'constant_case' => ['case' => 'lower'],
+        'lowercase_keywords' => true,
+        'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
+        'header_comment' => ['header' => $fileHeaderComment, 'separate' => 'both'],
+        'no_php4_constructor' => true,
+        'ordered_imports' => true,
+        'no_break_comment' => true,
+        'no_closing_tag' => true,
+        'no_spaces_after_function_name' => true,
+        'no_spaces_inside_parenthesis' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'single_blank_line_at_eof' => true,
+        'single_class_element_per_statement' => ['elements' => ['property']],
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+        'binary_operator_spaces' => true,
+        'blank_line_after_opening_tag' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['return'],
+        ],
+        'cast_spaces' => true,
+        'class_attributes_separation' => ['elements' => ['method' => 'one']],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => true,
+        'function_typehint_space' => true,
+        'include' => true,
+        'lowercase_cast' => true,
+        'lowercase_static_reference' => true,
+        'magic_constant_casing' => true,
+        'native_function_casing' => true,
+        'new_with_braces' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_comment' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => ['tokens' => [
+            'curly_brace_block',
+            'extra',
+            'parenthesis_brace_block',
+            'square_brace_block',
+            'throw',
+            'use',
+        ]],
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => ['use' => 'echo'],
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_trailing_comma_in_list_call' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_curly_braces' => true,
+        'no_unneeded_final_method' => true,
+        'no_unused_imports' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'normalize_index_brace' => true,
+        'object_operator_without_whitespace' => true,
+        'php_unit_fqcn_annotation' => true,
+        'phpdoc_align' => [
+            'align' => 'left',
+            'tags' => [
+                'method',
+                'param',
+                'property',
+                'return',
+                'throws',
+                'type',
+                'var',
+            ],
+        ],
+        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_alias_tag' => true,
+        'phpdoc_no_empty_return' => false,
+        'phpdoc_no_package' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_separation' => false,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_summary' => false,
+        'phpdoc_to_comment' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_var_without_name' => true,
+        'protected_to_private' => true,
+        'return_type_declaration' => true,
+        'semicolon_after_instruction' => true,
+        'short_scalar_cast' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_line_comment_style' => [
+            'comment_types' => ['hash'],
+        ],
+        'single_quote' => true,
+        'space_after_semicolon' => [
+            'remove_in_empty_for_expressions' => true,
+        ],
+        'standardize_increment' => true,
+        'standardize_not_equals' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline' => false,
+        'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
+        'whitespace_after_comma_in_array' => true,
+        'yoda_style' => false,
+        'ternary_to_null_coalescing' => true,
+        'visibility_required' => ['elements' => [
+            'const',
+            'method',
+            'property',
+        ]],
+        'native_function_invocation' => [
+            'include' => [
+                '@compiler_optimized'
+            ],
+            'scope' => 'namespaced'
+        ],
+        'native_function_type_declaration_casing' => true,
+        'no_alias_functions' => [
+            'sets' => [
+                '@internal'
+            ]
+        ],
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in([
+                __DIR__
+            ])->exclude([
+                __DIR__ . '/_documentation/',
+                __DIR__ . '/Resources/',
+                __DIR__ . '/vendor/',
+                __DIR__ . '/.github/',
+            ])
+    )
+    ->setFormat('checkstyle')
+;
+
+return $fixer;

--- a/API/ApprovalBundleApiController.php
+++ b/API/ApprovalBundleApiController.php
@@ -80,16 +80,16 @@ final class ApprovalBundleApiController extends AbstractController
     private $lockdownRepository;
 
     public function __construct(
-        ViewHandlerInterface          $viewHandler,
-        UserRepository                $userRepository,
-        EmailTool                     $emailTool,
-        UrlGeneratorInterface         $urlGenerator,
-        ApprovalRepository            $approvalRepository,
-        ApprovalHistoryRepository     $approvalHistoryRepository,
-        ApprovalStatusRepository      $approvalStatusRepository,
+        ViewHandlerInterface $viewHandler,
+        UserRepository $userRepository,
+        EmailTool $emailTool,
+        UrlGeneratorInterface $urlGenerator,
+        ApprovalRepository $approvalRepository,
+        ApprovalHistoryRepository $approvalHistoryRepository,
+        ApprovalStatusRepository $approvalStatusRepository,
         AuthorizationCheckerInterface $security,
-        TranslatorInterface           $translator,
-        LockdownRepository            $lockdownRepository
+        TranslatorInterface $translator,
+        LockdownRepository $lockdownRepository
     ) {
         $this->viewHandler = $viewHandler;
         $this->userRepository = $userRepository;
@@ -140,8 +140,7 @@ final class ApprovalBundleApiController extends AbstractController
 
         $nextApproveWeek = $this->approvalRepository->getNextApproveWeek($currentUser);
         $startOfWeek = $selectedDate->format('Y-m-d');
-        if($nextApproveWeek && $nextApproveWeek < $startOfWeek)
-        {
+        if ($nextApproveWeek && $nextApproveWeek < $startOfWeek) {
             return $this->error400($this->translator->trans('api.add_to_approve_previous_weeks'));
         }
 
@@ -241,6 +240,7 @@ final class ApprovalBundleApiController extends AbstractController
                 $this->approvalHistoryRepository->persistFlush($approveHistory);
             }
         }
+
         return $approval;
     }
 }

--- a/API/ApprovalBundleApiController.php
+++ b/API/ApprovalBundleApiController.php
@@ -9,7 +9,6 @@
 
 namespace KimaiPlugin\ApprovalBundle\API;
 
-use App\Entity\Team;
 use App\Repository\UserRepository;
 use DateTime;
 use Exception;
@@ -144,10 +143,10 @@ final class ApprovalBundleApiController extends AbstractController
             return $this->error400($this->translator->trans('api.add_to_approve_previous_weeks'));
         }
 
-        /** @var Approval $approval */
+        /** @var Approval|null $approval */
         $approval = $this->approvalRepository->findOneBy(['user' => $currentUser, 'startDate' => $selectedDate], ['creationDate' => 'DESC']);
 
-        if (!empty($approval)) {
+        if ($approval !== null) {
             $history = $approval->getHistory();
             $status = $history[\count($history) - 1]->getStatus()->getName();
             if ($status !== ApprovalStatus::NOT_SUBMITTED) {
@@ -156,7 +155,7 @@ final class ApprovalBundleApiController extends AbstractController
         }
 
         $approval = $this->approvalRepository->createApproval($selectedDate->format('Y-m-d'), $currentUser);
-        if ($approval) {
+        if ($approval !== null) {
             $approval = $this->createHistory($approval);
             $this->emailTool->sendApproveWeekEmail($approval, $this->approvalRepository);
             $this->lockdownRepository->updateLockWeek($approval, $this->approvalRepository);
@@ -188,7 +187,6 @@ final class ApprovalBundleApiController extends AbstractController
         return array_filter(
             $user->getTeams(),
             function ($team) use ($selectedUser) {
-                /** @var Team $team */
                 foreach ($team->getUsers() as $user) {
                     if ($user->getId() == $selectedUser) {
                         return true;

--- a/API/ApprovalNextWeekApiController.php
+++ b/API/ApprovalNextWeekApiController.php
@@ -9,7 +9,6 @@
 
 namespace KimaiPlugin\ApprovalBundle\API;
 
-use App\Entity\Team;
 use App\Repository\UserRepository;
 use Exception;
 use FOS\RestBundle\Controller\Annotations as Rest;
@@ -142,7 +141,6 @@ final class ApprovalNextWeekApiController extends AbstractController
         return array_filter(
             $user->getTeams(),
             function ($team) use ($selectedUserId) {
-                /** @var Team $team */
                 foreach ($team->getUsers() as $user) {
                     if ($user->getId() == $selectedUserId) {
                         return true;

--- a/API/ApprovalStatusApiController.php
+++ b/API/ApprovalStatusApiController.php
@@ -9,7 +9,6 @@
 
 namespace KimaiPlugin\ApprovalBundle\API;
 
-use App\Entity\Team;
 use App\Repository\UserRepository;
 use DateTime;
 use Exception;
@@ -144,7 +143,6 @@ final class ApprovalStatusApiController extends AbstractController
         return array_filter(
             $user->getTeams(),
             function ($team) use ($selectedUserId) {
-                /** @var Team $team */
                 foreach ($team->getUsers() as $user) {
                     if ($user->getId() == $selectedUserId) {
                         return true;
@@ -167,9 +165,9 @@ final class ApprovalStatusApiController extends AbstractController
     {
         $status = ApprovalStatus::NOT_SUBMITTED;
 
-        /** @var Approval $approval */
+        /** @var Approval|null $approval */
         $approval = $this->approvalRepository->findOneBy(['user' => $currentUser, 'startDate' => $selectedDate], ['creationDate' => 'DESC']);
-        if (!empty($approval)) {
+        if ($approval !== null) {
             $history = $approval->getHistory();
             $status = $history[\count($history) - 1]->getStatus()->getName();
         }

--- a/ApprovalBundle.php
+++ b/ApprovalBundle.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle;
 
 use App\Plugin\PluginInterface;

--- a/ApprovalBundle.php
+++ b/ApprovalBundle.php
@@ -10,8 +10,15 @@
 namespace KimaiPlugin\ApprovalBundle;
 
 use App\Plugin\PluginInterface;
+use KimaiPlugin\ApprovalBundle\DependencyInjection\Compiler\ApprovalSettingsCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ApprovalBundle extends Bundle implements PluginInterface
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ApprovalSettingsCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+    }
 }

--- a/Command/UserNotSubmittedCommand.php
+++ b/Command/UserNotSubmittedCommand.php
@@ -15,7 +15,6 @@ use KimaiPlugin\ApprovalBundle\Toolbox\EmailTool;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class UserNotSubmittedCommand extends Command
 {
@@ -33,22 +32,16 @@ class UserNotSubmittedCommand extends Command
      * @var EmailTool
      */
     private $emailTool;
-    /**
-     * @var UrlGeneratorInterface
-     */
-    private $urlGenerator;
 
     public function __construct(
         UserRepository $userRepository,
         EmailTool $emailTool,
-        ApprovalRepository $approvalRepository,
-        UrlGeneratorInterface $urlGenerator
+        ApprovalRepository $approvalRepository
     ) {
         parent::__construct();
         $this->userRepository = $userRepository;
         $this->emailTool = $emailTool;
         $this->approvalRepository = $approvalRepository;
-        $this->urlGenerator = $urlGenerator;
     }
 
     protected function configure(): void

--- a/Controller/ApprovalController.php
+++ b/Controller/ApprovalController.php
@@ -180,10 +180,10 @@ class ApprovalController extends AbstractController
                 $this->approvalRepository->getUrl($approval->getUser()->getId(), $approval->getStartDate()->format('Y-m-d'))
             );
             $this->createNewApproveHistory($approveId, ApprovalStatus::NOT_SUBMITTED, '', (new DateTime())->modify('+2 second')->format('d.m.Y H:i:s'));
-            
+
             // set all approvals + following approvals to NOT_SUBMITTED
             $this->resetAllLaterApprovals($this->approvalRepository->findAllLaterApprovals($approveId));
-            
+
             $this->lockdownRepository->updateLockWeek($approval, $this->approvalRepository);
         }
 
@@ -193,8 +193,9 @@ class ApprovalController extends AbstractController
         ]));
     }
 
-    private function resetAllLaterApprovals($approvalIdArray){
-        foreach ($approvalIdArray as $approvalId){
+    private function resetAllLaterApprovals($approvalIdArray)
+    {
+        foreach ($approvalIdArray as $approvalId) {
             $this->createNewApproveHistory($approvalId, ApprovalStatus::NOT_SUBMITTED, 'Reset due to earlier approval cancellation');
         }
     }
@@ -222,7 +223,7 @@ class ApprovalController extends AbstractController
      * @throws Exception
      */
     private function createNewApproveHistory(string $approveId, string $status, string $message = null, string $dateTime = 'now'): ?Approval
-    {        
+    {
         if ($approveId > 0) {
             $dateTime = new DateTime($dateTime);
             $approve = $this->approvalRepository->find($approveId);
@@ -252,7 +253,7 @@ class ApprovalController extends AbstractController
         $dateFirstMonthDay = (new DateTime($date))->modify('first day of this month')->format('Y-m-d');
         $todayFirstMonthDay = (new DateTime())->modify('first day of this month')->format('Y-m-d');
 
-        if ($dateFirstMonthDay < $todayFirstMonthDay){
+        if ($dateFirstMonthDay < $todayFirstMonthDay) {
             $users = $this->userRepository->findAll();
             $users = array_filter($users, function ($user) {
                 return $user->isEnabled() && !$user->isSuperAdmin();

--- a/Controller/ApprovalController.php
+++ b/Controller/ApprovalController.php
@@ -115,7 +115,7 @@ class ApprovalController extends AbstractController
             $this->emailTool->sendStatusChangedEmail(
                 $approval,
                 $this->getUser()->getUsername(),
-                $this->approvalRepository->getUrl($approval->getUser()->getId(), $approval->getStartDate()->format('Y-m-d'))
+                $this->approvalRepository->getUrl((string) $approval->getUser()->getId(), $approval->getStartDate()->format('Y-m-d'))
             );
             $this->lockdownRepository->updateLockWeek($approval, $this->approvalRepository);
         }
@@ -177,7 +177,7 @@ class ApprovalController extends AbstractController
             $this->emailTool->sendStatusChangedEmail(
                 $approval,
                 $this->getUser()->getUsername(),
-                $this->approvalRepository->getUrl($approval->getUser()->getId(), $approval->getStartDate()->format('Y-m-d'))
+                $this->approvalRepository->getUrl((string) $approval->getUser()->getId(), $approval->getStartDate()->format('Y-m-d'))
             );
             $this->createNewApproveHistory($approveId, ApprovalStatus::NOT_SUBMITTED, '', (new DateTime())->modify('+2 second')->format('d.m.Y H:i:s'));
 

--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -152,7 +152,7 @@ class WeekReportController extends AbstractController
 
         $selectedUserSundayIssue = $selectedUser->isFirstDayOfWeekSunday();
         $currentUserSundayIssue = $this->getUser()->isFirstDayOfWeekSunday();
- 
+
         return $this->render('@Approval/report_by_user.html.twig', [
             'approve' => $this->parseToHistoryView($userId, $startWeek),
             'week' => $this->formatting->parseDate(new DateTime($startWeek)),
@@ -385,10 +385,11 @@ class WeekReportController extends AbstractController
     {
         return array_reduce($rows, function ($toReturn, $row) {
             $currentUser = $this->getUser();
-            $isCurrentUserATeamLeader = in_array('ROLE_TEAMLEAD', $currentUser->getRoles());
-            if (!($row['user'] === $currentUser->getUsername() && $isCurrentUserATeamLeader && $row['status'] !== 'not_submitted' )) {
+            $isCurrentUserATeamLeader = \in_array('ROLE_TEAMLEAD', $currentUser->getRoles());
+            if (!($row['user'] === $currentUser->getUsername() && $isCurrentUserATeamLeader && $row['status'] !== 'not_submitted')) {
                 $toReturn[] = $row;
             }
+
             return $toReturn;
         }, []);
     }

--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -240,13 +240,15 @@ class WeekReportController extends AbstractController
         if ($form->isSubmitted()) {
             $data = $form->getData();
 
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY, $this->collectMetaField($data, FormEnum::MONDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY, $this->collectMetaField($data, FormEnum::TUESDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY, $this->collectMetaField($data, FormEnum::WEDNESDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY, $this->collectMetaField($data, FormEnum::THURSDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY, $this->collectMetaField($data, FormEnum::FRIDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY, $this->collectMetaField($data, FormEnum::SATURDAY));
-            $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY, $this->collectMetaField($data, FormEnum::SUNDAY));
+            if ($this->approvalSettings->canBeConfigured()) {
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY, $this->collectMetaField($data, FormEnum::MONDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY, $this->collectMetaField($data, FormEnum::TUESDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY, $this->collectMetaField($data, FormEnum::WEDNESDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY, $this->collectMetaField($data, FormEnum::THURSDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY, $this->collectMetaField($data, FormEnum::FRIDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY, $this->collectMetaField($data, FormEnum::SATURDAY));
+                $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY, $this->collectMetaField($data, FormEnum::SUNDAY));
+            }
             $this->settingsTool->setConfiguration(ConfigEnum::META_FIELD_EMAIL_LINK_URL, $data[FormEnum::EMAIL_LINK_URL]);
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START, $data[FormEnum::WORKFLOW_START]);
             $this->settingsTool->setConfiguration(ConfigEnum::CUSTOMER_FOR_FREE_DAYS, $this->collectCustomerForFreeDays($data));

--- a/DependencyInjection/ApprovalExtension.php
+++ b/DependencyInjection/ApprovalExtension.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;

--- a/DependencyInjection/Compiler/ApprovalSettingsCompilerPass.php
+++ b/DependencyInjection/Compiler/ApprovalSettingsCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\ApprovalBundle\DependencyInjection\Compiler;
+
+use KimaiPlugin\ApprovalBundle\Settings\DefaultSettings;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ApprovalSettingsCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $definition = $container->findDefinition('approval.settings');
+        if (!class_exists('\KimaiPlugin\MetaFieldsBundle\Repository\MetaFieldRuleRepository')) {
+            $definition->setClass(DefaultSettings::class);
+        }
+    }
+}

--- a/Entity/ApprovalHistory.php
+++ b/Entity/ApprovalHistory.php
@@ -10,7 +10,6 @@
 namespace KimaiPlugin\ApprovalBundle\Entity;
 
 use App\Entity\User;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalHistoryRepository;
 
@@ -52,13 +51,6 @@ class ApprovalHistory
      * @ORM\Column(type="text", nullable=true)
      */
     private $message;
-
-    public function __construct()
-    {
-        $this->user = new ArrayCollection();
-        $this->approval = new ArrayCollection();
-        $this->status = new ArrayCollection();
-    }
 
     /**
      * @return mixed

--- a/Entity/ApprovalStatus.php
+++ b/Entity/ApprovalStatus.php
@@ -18,7 +18,7 @@ use KimaiPlugin\ApprovalBundle\Repository\ApprovalStatusRepository;
  */
 class ApprovalStatus
 {
-    public const SUBMITTED = 'submitted'; 
+    public const SUBMITTED = 'submitted';
     public const GRANTED = 'granted'; //WRONG - only for migration
     public const DENIED = 'denied';
     public const APPROVED = 'approved';

--- a/Enumeration/ConfigEnum.php
+++ b/Enumeration/ConfigEnum.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Enumeration;
 
 abstract class ConfigEnum

--- a/Enumeration/FormEnum.php
+++ b/Enumeration/FormEnum.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Enumeration;
 
 abstract class FormEnum

--- a/Extension/FormattingExtension.php
+++ b/Extension/FormattingExtension.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Extension;
 
 use KimaiPlugin\ApprovalBundle\Toolbox\FormattingTool;

--- a/Form/SettingsForm.php
+++ b/Form/SettingsForm.php
@@ -15,11 +15,10 @@ use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
 use KimaiPlugin\ApprovalBundle\Enumeration\FormEnum;
 use KimaiPlugin\ApprovalBundle\Toolbox\FormTool;
 use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
-use KimaiPlugin\MetaFieldsBundle\Repository\MetaFieldRuleRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class SettingsForm extends AbstractType
@@ -107,17 +106,17 @@ class SettingsForm extends AbstractType
             'label' => 'label.email_link_url',
             'data' => $data,
             'required' => false
-        ]); 
+        ]);
 
         $workflowDate = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START);
-        if ($workflowDate == ""){
+        if ($workflowDate == '') {
             $workflowDate = '2000-01-01';
         }
         $builder->add(FormEnum::WORKFLOW_START, TextType::class, [
             'label' => 'label.workflow_start',
             'data' => $workflowDate,
             'required' => false
-        ]); 
+        ]);
 
         $builder->add(FormEnum::SUBMIT, SubmitType::class, [
             'label' => 'action.save',

--- a/Form/SettingsForm.php
+++ b/Form/SettingsForm.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SettingsForm extends AbstractType
 {
@@ -46,53 +47,62 @@ class SettingsForm extends AbstractType
         $this->customerRepository = $customerRepository;
     }
 
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'with_time' => true,
+        ]);
+    }
+
     /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $this->formTool->createMetaDataChoice(
-            FormEnum::MONDAY,
-            'label.meta_field_expected_working_time_on_monday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::TUESDAY,
-            'label.meta_field_expected_working_time_on_tuesday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::WEDNESDAY,
-            'label.meta_field_expected_working_time_on_wednesday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::THURSDAY,
-            'label.meta_field_expected_working_time_on_thursday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::FRIDAY,
-            'label.meta_field_expected_working_time_on_friday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::SATURDAY,
-            'label.meta_field_expected_working_time_on_saturday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY,
-            $builder
-        );
-        $this->formTool->createMetaDataChoice(
-            FormEnum::SUNDAY,
-            'label.meta_field_expected_working_time_on_sunday',
-            ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY,
-            $builder
-        );
+        if ($options['with_time'] === true) {
+            $this->formTool->createMetaDataChoice(
+                FormEnum::MONDAY,
+                'label.meta_field_expected_working_time_on_monday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::TUESDAY,
+                'label.meta_field_expected_working_time_on_tuesday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::WEDNESDAY,
+                'label.meta_field_expected_working_time_on_wednesday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::THURSDAY,
+                'label.meta_field_expected_working_time_on_thursday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::FRIDAY,
+                'label.meta_field_expected_working_time_on_friday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::SATURDAY,
+                'label.meta_field_expected_working_time_on_saturday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY,
+                $builder
+            );
+            $this->formTool->createMetaDataChoice(
+                FormEnum::SUNDAY,
+                'label.meta_field_expected_working_time_on_sunday',
+                ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY,
+                $builder
+            );
+        }
 
         $customer = $this->customerRepository->find($this->settingsTool->getConfiguration(ConfigEnum::CUSTOMER_FOR_FREE_DAYS));
         $builder->add(FormEnum::CUSTOMER_FOR_FREE_DAYS, CustomerType::class, [

--- a/Form/WeekByUserForm.php
+++ b/Form/WeekByUserForm.php
@@ -9,7 +9,6 @@
 
 namespace KimaiPlugin\ApprovalBundle\Form;
 
-use App\Form\Type\UserType;
 use App\Form\Type\WeekPickerType;
 use App\Reporting\WeekByUser;
 use Symfony\Component\Form\AbstractType;

--- a/Migrations/Version20220208134542.php
+++ b/Migrations/Version20220208134542.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Migrations/Version20220210154511.php
+++ b/Migrations/Version20220210154511.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Migrations/Version20220303101010.php
+++ b/Migrations/Version20220303101010.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Migrations/Version20220303134149.php
+++ b/Migrations/Version20220303134149.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Migrations/Version20220307092555.php
+++ b/Migrations/Version20220307092555.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Migrations/Version20220318122512.php
+++ b/Migrations/Version20220318122512.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;

--- a/Repository/ApprovalHistoryRepository.php
+++ b/Repository/ApprovalHistoryRepository.php
@@ -1,11 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalHistory;
-use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**
  * @method ApprovalHistory|null find($id, $lockMode = null, $lockVersion = null)

--- a/Repository/ApprovalRepository.php
+++ b/Repository/ApprovalRepository.php
@@ -168,7 +168,7 @@ class ApprovalRepository extends ServiceEntityRepository
     {
         $parseToViewArray = $this->getUserApprovals($users);
         $parseToViewArray = $this->addAllNotSubmittedUsers($parseToViewArray, $users);
-        
+
         $result = $parseToViewArray ? $this->sort($parseToViewArray) : [];
 
         return $this->getNewestPerUser($result);
@@ -251,8 +251,8 @@ class ApprovalRepository extends ServiceEntityRepository
         $firstDay = $firstDayWork ? $firstDayWork[0]->getBegin() : new DateTime('today');
 
         $approval_workflow_start = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START);
-        if ($approval_workflow_start == ""){
-            $approval_workflow_start = "0000-01-01";
+        if ($approval_workflow_start == '') {
+            $approval_workflow_start = '0000-01-01';
         }
         $approval_ws_start_week = (new DateTime($approval_workflow_start))->modify('-7 day')->format('Y-m-d');
 
@@ -409,11 +409,11 @@ class ApprovalRepository extends ServiceEntityRepository
         $allRows = $this->findAllWeek([$user]);
         $allRows = $this->filterWeeksApprovedOrSubmitted($allRows);
         $allRows = $this->filterWeeksLaterThan($allRows, $date->format('Y-m-d'));
-        
+
         $result = [];
-        foreach ($allRows as $week){
+        foreach ($allRows as $week) {
             $approvalId = end($this->findHistoryForUserAndWeek($userId, $week['startDate']))->getId();
-            if ($approvalId){
+            if ($approvalId) {
                 array_push($result, $approvalId);
             }
         }
@@ -536,10 +536,11 @@ class ApprovalRepository extends ServiceEntityRepository
     {
         return array_reduce(
             $rowArray,
-            function ($response, $item)  use ($dateString) {
+            function ($response, $item) use ($dateString) {
                 if ($item['startDate'] > $dateString) {
                     $response[] = $item;
                 }
+
                 return $response;
             },
             []
@@ -600,14 +601,14 @@ class ApprovalRepository extends ServiceEntityRepository
             return $user->getId();
         }, $users);
 
-        $approval_workflow_start = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START);        
-        if ($approval_workflow_start == ""){
-            $approval_workflow_start = "0000-01-01";
+        $approval_workflow_start = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START);
+        if ($approval_workflow_start == '') {
+            $approval_workflow_start = '0000-01-01';
         } else {
             $approval_workflow_start = (new DateTime($approval_workflow_start))->modify('-7 day')->format('Y-m-d');
         }
-        
-        $em = $this->getEntityManager();        
+
+        $em = $this->getEntityManager();
         $approvedList = $em->createQueryBuilder()
             ->select('ap')
             ->from(Approval::class, 'ap')
@@ -659,20 +660,21 @@ class ApprovalRepository extends ServiceEntityRepository
     public function getNextApproveWeek(User $user): ?string
     {
         $allRows = $this->findAllWeek([$user]);
-        $allNotSubmittedRows = $this->filterWeeksNotSubmitted($allRows);         
+        $allNotSubmittedRows = $this->filterWeeksNotSubmitted($allRows);
 
         // When there are past/current not submitted rows, return that date
-        if (!empty($allNotSubmittedRows)){
+        if (!empty($allNotSubmittedRows)) {
             return $allNotSubmittedRows[0]['startDate'];
         }
 
         // If there are no initial values, return nothing
-        if (empty($allRows)){
+        if (empty($allRows)) {
             return null;
         }
 
         // Otherwise, when there are $allRows, get the one which would be next (located in the future)
         $prevWeekDay = end($allRows)['startDate'];
-        return date('Y-m-d', strtotime($prevWeekDay. ' + 7 days'));
+
+        return date('Y-m-d', strtotime($prevWeekDay . ' + 7 days'));
     }
 }

--- a/Repository/ApprovalStatusRepository.php
+++ b/Repository/ApprovalStatusRepository.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Repository;
 
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -14,7 +21,6 @@ use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
  */
 class ApprovalStatusRepository extends ServiceEntityRepository
 {
-
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, ApprovalStatus::class);

--- a/Repository/LockdownRepository.php
+++ b/Repository/LockdownRepository.php
@@ -110,6 +110,13 @@ class LockdownRepository extends ServiceEntityRepository
         return $endDate;
     }
 
+    /**
+     * @param User $user
+     * @param ApprovalRepository $approvalRepository
+     * @return void
+     * @throws Exception
+     * @phpstan-ignore-next-line
+     */
     private function updateTeamleadersLock(User $user, ApprovalRepository $approvalRepository): void
     {
         foreach ($user->getTeams() as $team) {

--- a/Repository/LockdownRepository.php
+++ b/Repository/LockdownRepository.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Repository;
 
 use App\Entity\User;
@@ -126,6 +133,7 @@ class LockdownRepository extends ServiceEntityRepository
         } else {
             $endDate->modify('midnight')->modify('+1 day')->modify('-1 second');
         }
+
         return $endDate;
     }
 }

--- a/Repository/ReportRepository.php
+++ b/Repository/ReportRepository.php
@@ -138,6 +138,7 @@ class ReportRepository extends ServiceEntityRepository
         $record['details'][$value['description']] = $value;
 
         $report[$title] = $record;
+
         return $report;
     }
 
@@ -147,7 +148,7 @@ class ReportRepository extends ServiceEntityRepository
 
         $days = $report[$title]['days'];
         $day = $days->getDayByReportDate($value['date']);
-        $day->setTotalDuration($day->getTotalDuration() + (int)$value['duration']);
+        $day->setTotalDuration($day->getTotalDuration() + (int) $value['duration']);
 
         if (isset($report[$title]['details'][$value['description']])) {
             $report = $this->updateExistingDescription($report, $title, $value);
@@ -155,6 +156,7 @@ class ReportRepository extends ServiceEntityRepository
             $report = $this->creatNewDescription($begin, $end, $user, $value, $report, $title);
         }
         $report[$title]['days'] = $days;
+
         return $report;
     }
 }

--- a/Repository/ReportRepository.php
+++ b/Repository/ReportRepository.php
@@ -14,7 +14,6 @@ use App\Entity\User;
 use App\Model\DailyStatistic;
 use App\Repository\ActivityRepository;
 use App\Repository\ProjectRepository;
-use App\Repository\TimesheetRepository;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -27,18 +26,20 @@ use Doctrine\Persistence\ManagerRegistry;
 class ReportRepository extends ServiceEntityRepository
 {
     /**
-     * @var TimesheetRepository
+     * @var ProjectRepository
      */
-    private $timesheetRepository;
+    private $projectRepository;
+    /**
+     * @var ActivityRepository
+     */
+    private $activityRepository;
 
     public function __construct(
         ManagerRegistry $registry,
-        TimesheetRepository $timesheetRepository,
         ProjectRepository $projectRepository,
         ActivityRepository $activityRepository
     ) {
         parent::__construct($registry, Timesheet::class);
-        $this->timesheetRepository = $timesheetRepository;
         $this->projectRepository = $projectRepository;
         $this->activityRepository = $activityRepository;
     }

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -12,3 +12,9 @@ services:
     KimaiPlugin\ApprovalBundle\API\:
         resource: '../../API'
         tags: ['controller.service_arguments']
+
+    approval.settings:
+        class: KimaiPlugin\ApprovalBundle\Settings\MetaFieldSettings
+
+    KimaiPlugin\ApprovalBundle\Settings\ApprovalSettingsInterface:
+        alias: 'approval.settings'

--- a/Settings/ApprovalSettingsInterface.php
+++ b/Settings/ApprovalSettingsInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\ApprovalBundle\Settings;
+
+use App\Entity\User;
+
+interface ApprovalSettingsInterface
+{
+    /**
+     * Returns the list of fields to choose from.
+     *
+     * @return array
+     */
+    public function getRules(): array;
+
+    /**
+     * Find data for the given ID.
+     *
+     * @param string|int $id
+     * @return mixed
+     */
+    public function find($id): mixed;
+
+    /**
+     * Whether this setting repository can be configured.
+     *
+     * @return bool
+     */
+    public function canBeConfigured(): bool;
+
+    /**
+     * Returns if the settings are fully configured.
+     *
+     * @return bool
+     */
+    public function isFullyConfigured(): bool;
+
+    public function getWorkingTimeForMonday(User $user): int;
+
+    public function getWorkingTimeForTuesday(User $user): int;
+
+    public function getWorkingTimeForWednesday(User $user): int;
+
+    public function getWorkingTimeForThursday(User $user): int;
+
+    public function getWorkingTimeForFriday(User $user): int;
+
+    public function getWorkingTimeForSaturday(User $user): int;
+
+    public function getWorkingTimeForSunday(User $user): int;
+}

--- a/Settings/DefaultSettings.php
+++ b/Settings/DefaultSettings.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\ApprovalBundle\Settings;
+
+use App\Entity\User;
+use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
+
+class DefaultSettings implements ApprovalSettingsInterface
+{
+    public function canBeConfigured(): bool
+    {
+        return false;
+    }
+
+    public function isFullyConfigured(): bool
+    {
+        return true;
+    }
+
+    public function getRules(): array
+    {
+        return [];
+    }
+
+    public function find($id): mixed
+    {
+        return null;
+    }
+
+    public function getWorkingTimeForDay(User $user, string $name): int
+    {
+        return 0;
+    }
+
+    public function getWorkingTimeForMonday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY);
+    }
+
+    public function getWorkingTimeForTuesday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY);
+    }
+
+    public function getWorkingTimeForWednesday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY);
+    }
+
+    public function getWorkingTimeForThursday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY);
+    }
+
+    public function getWorkingTimeForFriday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY);
+    }
+
+    public function getWorkingTimeForSaturday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY);
+    }
+
+    public function getWorkingTimeForSunday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY);
+    }
+}

--- a/Settings/MetaFieldSettings.php
+++ b/Settings/MetaFieldSettings.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\ApprovalBundle\Settings;
+
+use App\Entity\User;
+use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
+use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
+use KimaiPlugin\MetaFieldsBundle\Repository\MetaFieldRuleRepository;
+
+/**
+ * @phpstan-ignore-next-line
+ */
+class MetaFieldSettings implements ApprovalSettingsInterface
+{
+    private $metaFieldRuleRepository;
+    private $settingsTool;
+
+    public function __construct(MetaFieldRuleRepository $metaFieldRuleRepository, SettingsTool $settingsTool)
+    {
+        $this->metaFieldRuleRepository = $metaFieldRuleRepository;
+        $this->settingsTool = $settingsTool;
+    }
+
+    public function canBeConfigured(): bool
+    {
+        return true;
+    }
+
+    public function isFullyConfigured(): bool
+    {
+        return $this->settingsTool->isAllSettingsUpdated();
+    }
+
+    public function getRules(): array
+    {
+        return $this->metaFieldRuleRepository->getRules();
+    }
+
+    public function find($id): mixed
+    {
+        return $this->metaFieldRuleRepository->find($id);
+    }
+
+    public function getWorkingTimeForDay(User $user, string $name): int
+    {
+        $metaField = $this->metaFieldRuleRepository->find(
+            $this->settingsTool->getConfiguration($name)
+        );
+
+        if ($metaField === null) {
+            return 0;
+        }
+
+        return $user->getPreferenceValue($metaField->getName());
+    }
+
+    public function getWorkingTimeForMonday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_MONDAY);
+    }
+
+    public function getWorkingTimeForTuesday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_TUESDAY);
+    }
+
+    public function getWorkingTimeForWednesday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_WEDNESDAY);
+    }
+
+    public function getWorkingTimeForThursday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_THURSDAY);
+    }
+
+    public function getWorkingTimeForFriday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_FRIDAY);
+    }
+
+    public function getWorkingTimeForSaturday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SATURDAY);
+    }
+
+    public function getWorkingTimeForSunday(User $user): int
+    {
+        return $this->getWorkingTimeForDay($user, ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY);
+    }
+}

--- a/Toolbox/BreakTimeCheckToolGER.php
+++ b/Toolbox/BreakTimeCheckToolGER.php
@@ -10,18 +10,12 @@
 namespace KimaiPlugin\ApprovalBundle\Toolbox;
 
 use App\Entity\Timesheet;
-use App\Repository\TimesheetRepository;
 use Exception;
 use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BreakTimeCheckToolGER
 {
-    /**
-     * @var TimesheetRepository
-     */
-    private $timesheetRepository;
-
     /**
      * @var TranslatorInterface
      */
@@ -31,9 +25,8 @@ class BreakTimeCheckToolGER
      */
     private $settingsTool;
 
-    public function __construct(TimesheetRepository $timesheetRepository, TranslatorInterface $translator, SettingsTool $settingsTool)
+    public function __construct(TranslatorInterface $translator, SettingsTool $settingsTool)
     {
-        $this->timesheetRepository = $timesheetRepository;
         $this->translator = $translator;
         $this->settingsTool = $settingsTool;
     }
@@ -79,7 +72,7 @@ class BreakTimeCheckToolGER
 
             if ($timesheet->getEnd()) {
                 if (\array_key_exists($hash, $result)) {
-                    if (!\is_null($result[$hash]['lastEnd']->getTimestamp())) {
+                    if (\array_key_exists('lastEnd', $result[$hash])) {
                         $breakDuration = $timesheet->getBegin()->getTimestamp() - $result[$hash]['lastEnd']->getTimestamp();
 
                         $result[$hash]['duration'] += $timesheet->getDuration();

--- a/Toolbox/BreakTimeCheckToolGER.php
+++ b/Toolbox/BreakTimeCheckToolGER.php
@@ -158,7 +158,7 @@ class BreakTimeCheckToolGER
             for ($i = 0; $i < \count($value) - 1; $i++) {
                 $timesheetOne = $value[$i]->getEnd()->getTimestamp();
                 $timesheetTwo = $value[$i + 1]->getBegin()->getTimestamp();
-                if ($value[$i]->getEnd() == null){
+                if ($value[$i]->getEnd() == null) {
                     $errors[$value[$i + 1]->getBegin()->format('Y-m-d')][] = $this->translator->trans('error.no_end_date');
                 }
                 if (abs($timesheetOne - $timesheetTwo) < 11 * 60 * 60 && $value[$i]->getEnd()->format('Y-m-d') < $value[$i + 1]->getEnd()->format('Y-m-d')) {    // 11h * 60 * 60 -> to seconds

--- a/Toolbox/EmailTool.php
+++ b/Toolbox/EmailTool.php
@@ -15,7 +15,6 @@ use App\Repository\UserRepository;
 use KimaiPlugin\ApprovalBundle\Entity\Approval;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
-use KimaiPlugin\MetaFieldsBundle\Repository\MetaFieldRuleRepository;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
@@ -40,29 +39,17 @@ class EmailTool
      * @var Formatting
      */
     private $formatting;
-    /**
-     * @var SettingsTool
-     */
-    private $settingsTool;
-    /**
-     * @var MetaFieldRuleRepository
-     */
-    private $metaFieldRuleRepository;
 
     public function __construct(
         TranslatorInterface $translator,
         KimaiMailer $kimaiMailer,
         UserRepository $userRepository,
-        Formatting $formatting,
-        SettingsTool $settingsTool,
-        MetaFieldRuleRepository $metaFieldRuleRepository
+        Formatting $formatting
     ) {
         $this->kimaiMailer = $kimaiMailer;
         $this->translator = $translator;
         $this->userRepository = $userRepository;
         $this->formatting = $formatting;
-        $this->settingsTool = $settingsTool;
-        $this->metaFieldRuleRepository = $metaFieldRuleRepository;
     }
 
     public function sendStatusChangedEmail(Approval $approval, string $approver, string $url): bool
@@ -106,7 +93,7 @@ class EmailTool
                 'submitter' => $submitter,
                 'approver' => $approver,
                 'week' => $this->formatting->parseDate(clone $approval->getStartDate()),
-                'url' => $approvalRepository->getUrl($user->getId(), $approval->getStartDate()->format('Y-m-d'))
+                'url' => $approvalRepository->getUrl((string) $user->getId(), $approval->getStartDate()->format('Y-m-d'))
             ];
             $email = (new TemplatedEmail())
                 ->to(new Address($user->getEmail()))

--- a/Toolbox/EmailTool.php
+++ b/Toolbox/EmailTool.php
@@ -20,7 +20,6 @@ use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mime\Address;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EmailTool
@@ -64,7 +63,7 @@ class EmailTool
         $this->formatting = $formatting;
         $this->settingsTool = $settingsTool;
         $this->metaFieldRuleRepository = $metaFieldRuleRepository;
-    } 
+    }
 
     public function sendStatusChangedEmail(Approval $approval, string $approver, string $url): bool
     {

--- a/Toolbox/FormTool.php
+++ b/Toolbox/FormTool.php
@@ -10,7 +10,7 @@
 namespace KimaiPlugin\ApprovalBundle\Toolbox;
 
 use Doctrine\ORM\EntityRepository;
-use KimaiPlugin\MetaFieldsBundle\Repository\MetaFieldRuleRepository;
+use KimaiPlugin\ApprovalBundle\Settings\ApprovalSettingsInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -22,15 +22,11 @@ class FormTool
     private $settingsTool;
 
     /**
-     * @var MetaFieldRuleRepository
+     * @var ApprovalSettingsInterface
      */
     private $metaFieldRuleRepository;
 
-    /**
-     * @param SettingsTool $settingsTool
-     * @param MetaFieldRuleRepository $metaFieldRuleRepository
-     */
-    public function __construct(SettingsTool $settingsTool, MetaFieldRuleRepository $metaFieldRuleRepository)
+    public function __construct(SettingsTool $settingsTool, ApprovalSettingsInterface $metaFieldRuleRepository)
     {
         $this->settingsTool = $settingsTool;
         $this->metaFieldRuleRepository = $metaFieldRuleRepository;
@@ -44,7 +40,7 @@ class FormTool
      */
     public function createMetaDataChoice($child, $label, $key, FormBuilderInterface $builder)
     {
-        $data = empty($this->settingsTool->getConfiguration($key)) ? null : $this->metaFieldRuleRepository->findOneBy(['id' => $this->settingsTool->getConfiguration($key)]);
+        $data = empty($this->settingsTool->getConfiguration($key)) ? null : $this->metaFieldRuleRepository->find($this->settingsTool->getConfiguration($key));
 
         $builder->add($child, ChoiceType::class, [
             'label' => $label,

--- a/Toolbox/FormattingTool.php
+++ b/Toolbox/FormattingTool.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\ApprovalBundle\Toolbox;
 
 use DateTime;

--- a/Toolbox/FormattingTool.php
+++ b/Toolbox/FormattingTool.php
@@ -29,21 +29,21 @@ class FormattingTool
     }
 
     /**
-     * @param $duration
-     * @return float|int
+     * @param float|int $duration
+     * @return string
      */
-    public function formattingDurationToHours($duration)
+    public function formattingDurationToHours($duration): string
     {
         return $this->formattingNumber($duration / 60 / 60);
     }
 
     /**
-     * @param $duration
-     * @return string
+     * @param float|int $duration
+     * @return int
      */
     public function formattingDurationToSeconds($duration)
     {
-        return $duration * 60 * 60;
+        return (int) ($duration * 60 * 60);
     }
 
     /**
@@ -51,7 +51,7 @@ class FormattingTool
      * @param int $precision
      * @return string
      */
-    public function formattingNumber($number, $precision = 2)
+    public function formattingNumber($number, $precision = 2): string
     {
         return number_format(round($number, $precision), $precision, $this->translator->trans('format.decimal_separator'), $this->translator->trans('format.thousands_separator'));
     }

--- a/Toolbox/SettingsTool.php
+++ b/Toolbox/SettingsTool.php
@@ -19,6 +19,7 @@ class SettingsTool
      * @var ConfigurationRepository
      */
     private $configurationRepository;
+    private $cache = [];
 
     /**
      * @param ConfigurationRepository $configurationRepository
@@ -34,12 +35,15 @@ class SettingsTool
      */
     public function getConfiguration($key)
     {
-        $config = $this->configurationRepository->findOneBy(['name' => $key]);
-        if ($config) {
-            return $config->getValue() ?? '';
+        if (!array_key_exists($key, $this->cache)) {
+            $config = $this->configurationRepository->findOneBy(['name' => $key]);
+            if ($config === null) {
+                return '';
+            }
+            $this->cache[$key] = $config->getValue() ?? '';
         }
 
-        return '';
+        return $this->cache[$key];
     }
 
     /**
@@ -49,6 +53,8 @@ class SettingsTool
      */
     public function setConfiguration($key, $value)
     {
+        $this->cache = [];
+
         $configuration = $this->configurationRepository->findOneBy(['name' => $key]);
 
         if ($configuration === null) {

--- a/Toolbox/SettingsTool.php
+++ b/Toolbox/SettingsTool.php
@@ -86,6 +86,7 @@ class SettingsTool
         if ($this->getConfiguration(ConfigEnum::META_FIELD_EXPECTED_WORKING_TIME_ON_SUNDAY) === '') {
             return false;
         }
+
         return true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,26 @@
             "require": "1.17",
             "name": "ApprovalBundle"
         }
+    },
+    "scripts": {
+        "codestyle": "vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=none",
+        "codestyle-fix": "vendor/bin/php-cs-fixer fix",
+        "codestyle-check": "vendor/bin/php-cs-fixer fix --dry-run --verbose --using-cache=no --show-progress=none --format=checkstyle",
+        "phpstan": "vendor/bin/phpstan analyse . -c phpstan.neon --level=6",
+        "linting": [
+            "composer validate --strict --no-check-version",
+            "@codestyle-check",
+            "@phpstan"
+        ]
+    },
+    "require": {
+        "doctrine/dbal": "^2.1"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "kevinpapst/kimai2": "^1.17",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-doctrine": "^1.0",
+        "phpstan/phpstan-symfony": "^1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,9 @@
 {
-    "name": "approval-bundle",
-    "description": "A Kimai 2 Plugin to manage approvals and supporting related API",
+    "name": "glassconsulting/approval-bundle",
+    "description": "A Kimai plugin to manage approvals and supporting related API",
     "homepage": "https://glacon.eu",
     "type": "kimai-plugin",
     "version": "0.9.3",
-    "require": {
-        "kimai/kimai2-composer": "*"
-    },
     "license": "MIT",
     "authors": [
         {
@@ -18,7 +15,6 @@
     "extra": {
         "kimai": {
             "require": "1.17",
-            "version": "0.9.3",
             "name": "ApprovalBundle"
         }
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ includes:
 parameters:
     excludePaths:
         - vendor/
+        - Settings/MetaFieldSettings.php
     treatPhpDocTypesAsCertain: false
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+includes:
+    - %rootDir%/../phpstan-doctrine/extension.neon
+    - %rootDir%/../phpstan-symfony/extension.neon
+    - %rootDir%/../phpstan-symfony/rules.neon
+
+parameters:
+    excludePaths:
+        - vendor/
+    treatPhpDocTypesAsCertain: false
+    inferPrivatePropertyTypeFromConstructor: true
+    ignoreErrors:
+        - '#Access to an undefined property Faker\\Generator::\$catchPhrase.#'
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,5 @@ parameters:
         - vendor/
     treatPhpDocTypesAsCertain: false
     inferPrivatePropertyTypeFromConstructor: true
-    ignoreErrors:
-        - '#Access to an undefined property Faker\\Generator::\$catchPhrase.#'
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
This is a huge PR, sorry for that!

It contains:
1. new CI tools
2. A new interface and service to use the bundle WITHOUT meta-fields and daily working times - fixes #4 
3. Code style and fixes

You could only use some commits if you prefer that.

First of all: I added a Github workflow to lint the entire codebase and prevent accidental code problems by using PHP-CS for code styles and phpstan for static code analysis.

I applied both tools, so big parts of the changes are "fixes".

With the changes from (2) anyone can now install the bundle and use it directly. People who want to check their working times can install the MetaField Bundle and configure the fields.

And please test it in detail, because my system has no MetaField setting for the working times. So I did not test that the refactoring did what I wanted... even though I expect that got it right .... but you never know 😁 
