### PR TITLE
Update MetaFieldSettings.php

### DIFF
--- a/Settings/MetaFieldSettings.php
+++ b/Settings/MetaFieldSettings.php
@@ -58,6 +58,10 @@ class MetaFieldSettings implements ApprovalSettingsInterface
             return 0;
         }
 
+        if ($user->getPreferenceValue($metaField->getName()) === null) {
+            return 0;
+        }
+
         return $user->getPreferenceValue($metaField->getName());
     }
 


### PR DESCRIPTION
this change (line 61-63) will fix an error on my system - please x-check ...

[2023-02-01 11:31:20] request.CRITICAL: Uncaught PHP Exception TypeError: "KimaiPlugin\ApprovalBundle\Settings\MetaFieldSettings::getWorkingTimeForDay(): Return value must be of type int, null returned" at /volume1/web/kimai-1.30.5/var/plugins/ApprovalBundle/Settings/MetaFieldSettings.php line 61 {"exception":"[object] (TypeError(code: 0): KimaiPlugin\\ApprovalBundle\\Settings\\MetaFieldSettings::getWorkingTimeForDay(): Return value must be of type int, null returned at /volume1/web/kimai-1.30.5/var/plugins/ApprovalBundle/Settings/MetaFieldSettings.php:61)"} []
[2023-02-01 11:31:20] php.CRITICAL: Uncaught Error: KimaiPlugin\ApprovalBundle\Settings\MetaFieldSettings::getWorkingTimeForDay(): Return value must be of type int, null returned {"exception":"[object] (TypeError(code: 0): KimaiPlugin\\ApprovalBundle\\Settings\\MetaFieldSettings::getWorkingTimeForDay(): Return value must be of type int, null returned at /volume1/web/kimai-1.30.5/var/plugins/ApprovalBundle/Settings/MetaFieldSettings.php:61)"} []