### PR TITLE
use correct base class for migration

### DIFF
--- a/Migrations/Version20220208134542.php
+++ b/Migrations/Version20220208134542.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220208134542.php
+++ b/Migrations/Version20220208134542.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220210154511.php
+++ b/Migrations/Version20220210154511.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20220210154511.php
+++ b/Migrations/Version20220210154511.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20220303101010.php
+++ b/Migrations/Version20220303101010.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20220303101010.php
+++ b/Migrations/Version20220303101010.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20220303134149.php
+++ b/Migrations/Version20220303134149.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220303134149.php
+++ b/Migrations/Version20220303134149.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220307092555.php
+++ b/Migrations/Version20220307092555.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220307092555.php
+++ b/Migrations/Version20220307092555.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20220318122512.php
+++ b/Migrations/Version20220318122512.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20220318122512.php
+++ b/Migrations/Version20220318122512.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 
 /**

--- a/Migrations/Version20221118162725.php
+++ b/Migrations/Version20221118162725.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20221118162725.php
+++ b/Migrations/Version20221118162725.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20231016134127.php
+++ b/Migrations/Version20231016134127.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace ApprovalBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use App\Doctrine\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/Migrations/Version20231016134127.php
+++ b/Migrations/Version20231016134127.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 
 namespace ApprovalBundle\Migrations;
 
-use Doctrine\DBAL\Schema\Schema;
 use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!


### PR DESCRIPTION
This fixes some Doctrine deprecations, which only happen during install.

The upcoming Doctrine 4 will handle transactions in Migrations different.
The Kimai base class takes care of the correct implementation.