### PR TITLE
Feature/v2 add options for Teamlead self approve & System-Admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1 to 2.0.2
+
+- new option to allow system-administrators to be included in approvals
+- new option to allow teamlead to self-approve the own weeks
+
 ## 2.0.0
 
 - Compatibility with Kimai 2 (tested with 2.6.0)

--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -191,9 +191,6 @@ class WeekReportController extends BaseApprovalController
             }
         }
         $pastRows = $this->approvalRepository->filterPastWeeksNotApproved($pastRows);
-        //$pastRows = $this->reduceRows($pastRows);
-        //$currentRows = $this->reduceRows($currentRows);
-        //$futureRows = $this->reduceRows($futureRows);
 
         return $this->render('@Approval/to_approve.html.twig', [
             'current_tab' => 'to_approve',

--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -37,6 +37,7 @@ use KimaiPlugin\ApprovalBundle\Repository\ReportRepository;
 use KimaiPlugin\ApprovalBundle\Toolbox\BreakTimeCheckToolGER;
 use KimaiPlugin\ApprovalBundle\Toolbox\Formatting;
 use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
+use KimaiPlugin\ApprovalBundle\Toolbox\SecurityTool;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,6 +50,7 @@ class WeekReportController extends BaseApprovalController
 {
     public function __construct(
         private SettingsTool $settingsTool,
+        private SecurityTool $securityTool,
         private UserRepository $userRepository,
         private ApprovalHistoryRepository $approvalHistoryRepository,
         private ApprovalRepository $approvalRepository,
@@ -125,6 +127,9 @@ class WeekReportController extends BaseApprovalController
             $overtimeDuration = $this->approvalRepository->getExpectedActualDurationsForYear($selectedUser, $end);
         }
 
+        $canManageHimself = $this->securityTool->canViewAllApprovals() || ($this->securityTool->canViewTeamApprovals() && 
+            ($this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY) == "1"));
+
         return $this->render('@Approval/report_by_user.html.twig', [
             'approve' => $this->parseToHistoryView($userId, $startWeek),
             'week' => $this->formatting->parseDate(new DateTime($startWeek)),
@@ -139,11 +144,7 @@ class WeekReportController extends BaseApprovalController
             'approveId' => empty($approvals) ? 0 : $approvals->getId(),
             'status' => $status,
             'current_tab' => 'weekly_report',
-            'canManageHimself' => (
-                $this->canManageTeam() && !$this->isGranted('ROLE_SUPER_ADMIN')
-            ) || !(
-                $this->canManageTeam() && $this->canManageAllPerson()
-            ),
+            'canManageHimself' => $canManageHimself,
             'currentUser' => $this->getUser()->getId(),
             'expectedDuration' => $expectedDuration,
             'yearDuration' => $overtimeDuration,
@@ -161,7 +162,11 @@ class WeekReportController extends BaseApprovalController
     #[IsGranted(new Expression("is_granted('view_team_approval') or is_granted('view_all_approval')"))]
     public function toApprove(): Response
     {
-        $users = $this->getUsers(false);
+        if ($this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY) == "1") {
+            $users = $this->getUsers(true);
+        } else {
+            $users = $this->getUsers(false);
+        }
 
         $warningNoUsers = false;
         if (empty($users)) {
@@ -186,9 +191,9 @@ class WeekReportController extends BaseApprovalController
             }
         }
         $pastRows = $this->approvalRepository->filterPastWeeksNotApproved($pastRows);
-        $pastRows = $this->reduceRows($pastRows);
-        $currentRows = $this->reduceRows($currentRows);
-        $futureRows = $this->reduceRows($futureRows);
+        //$pastRows = $this->reduceRows($pastRows);
+        //$currentRows = $this->reduceRows($currentRows);
+        //$futureRows = $this->reduceRows($futureRows);
 
         return $this->render('@Approval/to_approve.html.twig', [
             'current_tab' => 'to_approve',
@@ -292,6 +297,8 @@ class WeekReportController extends BaseApprovalController
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_WORKFLOW_START, $data[FormEnum::WORKFLOW_START]);
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_OVERTIME_NY, $data[FormEnum::OVERTIME_NY]);
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_BREAKCHECKS_NY, $data[FormEnum::BREAKCHECKS_NY]);
+            $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY, $data[FormEnum::INCLUDE_ADMIN_NY]);
+            $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY, $data[FormEnum::TEAMLEAD_SELF_APPROVE_NY]);
             $this->settingsTool->setConfiguration(ConfigEnum::CUSTOMER_FOR_FREE_DAYS, $this->collectCustomerForFreeDays($data));
 
             $this->flashSuccess('action.update.success');
@@ -334,7 +341,8 @@ class WeekReportController extends BaseApprovalController
         }
 
         $users = array_reduce($users, function ($current, $user) {
-            if ($user->isEnabled() && !$user->isSuperAdmin()) {
+            $includeSuperAdmin = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY) == "1";
+            if ($user->isEnabled() && (!$user->isSuperAdmin() || $includeSuperAdmin)) {
                 $current[] = $user;
             }
 
@@ -349,7 +357,7 @@ class WeekReportController extends BaseApprovalController
                 }
             );
         }
-
+        
         return $users;
     }
 

--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -37,6 +37,7 @@ use KimaiPlugin\ApprovalBundle\Repository\ReportRepository;
 use KimaiPlugin\ApprovalBundle\Toolbox\BreakTimeCheckToolGER;
 use KimaiPlugin\ApprovalBundle\Toolbox\Formatting;
 use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
+use KimaiPlugin\ApprovalBundle\Toolbox\SecurityTool;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,6 +50,7 @@ class WeekReportController extends BaseApprovalController
 {
     public function __construct(
         private SettingsTool $settingsTool,
+        private SecurityTool $securityTool,
         private UserRepository $userRepository,
         private ApprovalHistoryRepository $approvalHistoryRepository,
         private ApprovalRepository $approvalRepository,
@@ -125,6 +127,9 @@ class WeekReportController extends BaseApprovalController
             $overtimeDuration = $this->approvalRepository->getExpectedActualDurationsForYear($selectedUser, $end);
         }
 
+        $canManageHimself = $this->securityTool->canViewAllApprovals() || ($this->securityTool->canViewTeamApprovals() && 
+            ($this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY) == "1"));
+
         return $this->render('@Approval/report_by_user.html.twig', [
             'approve' => $this->parseToHistoryView($userId, $startWeek),
             'week' => $this->formatting->parseDate(new DateTime($startWeek)),
@@ -139,6 +144,7 @@ class WeekReportController extends BaseApprovalController
             'approveId' => empty($approvals) ? 0 : $approvals->getId(),
             'status' => $status,
             'current_tab' => 'weekly_report',
+            'canManageHimself' => $canManageHimself,
             'currentUser' => $this->getUser()->getId(),
             'expectedDuration' => $expectedDuration,
             'yearDuration' => $overtimeDuration,

--- a/Enumeration/ConfigEnum.php
+++ b/Enumeration/ConfigEnum.php
@@ -17,4 +17,6 @@ abstract class ConfigEnum
     public const APPROVAL_WORKFLOW_START = 'approval.workflow_start';
     public const APPROVAL_OVERTIME_NY = 'approval.overtime_ny';
     public const APPROVAL_BREAKCHECKS_NY = 'approval.breakchecks_ny';
+    public const APPROVAL_INCLUDE_ADMIN_NY = 'approval.include_admin_ny';
+    public const APPROVAL_TEAMLEAD_SELF_APPROVE_NY = 'approval.teamlead_selfapprove_ny';
 }

--- a/Enumeration/FormEnum.php
+++ b/Enumeration/FormEnum.php
@@ -25,4 +25,6 @@ abstract class FormEnum
     public const WORKFLOW_START = 'workflow_start';
     public const OVERTIME_NY = 'approval_overtime_ny';
     public const BREAKCHECKS_NY = 'approval_breakchecks_ny';
+    public const INCLUDE_ADMIN_NY = 'approval_include_admin_ny';
+    public const TEAMLEAD_SELF_APPROVE_NY = 'approval_teamlead_selfapprove_ny';
 }

--- a/Form/SettingsForm.php
+++ b/Form/SettingsForm.php
@@ -74,6 +74,30 @@ class SettingsForm extends AbstractType
           'required' => false
         ]);
 
+        if ($this->settingsTool->isInConfiguration(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY)){
+            $adminchecks = $this->formTool->isChecked(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY);
+        } else {
+            $adminchecks = false;
+        }
+
+        $builder->add(FormEnum::INCLUDE_ADMIN_NY, CheckboxType::class, [
+            'label' => 'label.approval_include_admin_ny',
+            'data' => $adminchecks,
+            'required' => false
+        ]);
+
+        if ($this->settingsTool->isInConfiguration(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY)) {
+            $leadselfchecks = $this->formTool->isChecked(ConfigEnum::APPROVAL_TEAMLEAD_SELF_APPROVE_NY);
+        } else {
+            $leadselfchecks = false;            
+        }
+        
+        $builder->add(FormEnum::TEAMLEAD_SELF_APPROVE_NY, CheckboxType::class, [
+            'label' => 'label.approval_teamlead_selfapprove_ny',
+            'data' => $leadselfchecks,
+            'required' => false
+        ]);
+
         $builder->add(FormEnum::SUBMIT, SubmitType::class, [
             'label' => 'action.save',
             'attr' => ['class' => 'btn btn-primary']

--- a/Resources/translations/messages.de.xlf
+++ b/Resources/translations/messages.de.xlf
@@ -404,6 +404,14 @@
         <source>label.approval_breakchecks_ny</source>
         <target>Berechne Pausenzeiten-Probleme</target>
       </trans-unit>
+      <trans-unit id="Mdn3yh_" resname="label.approval_include_admin_ny">
+        <source>label.approval_include_admin_ny</source>
+        <target>Approvals für System-Administratoren</target>
+      </trans-unit>
+      <trans-unit id="9yM8I2U" resname="label.approval_teamlead_selfapprove_ny">
+        <source>label.approval_teamlead_selfapprove_ny</source>
+        <target>Self Approve für Teamleiter</target>
+      </trans-unit>
       <trans-unit id="NUgf0fZ" resname="description.workday_history">
         <source>description.workday_history</source>
         <target>

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -404,6 +404,14 @@
         <source>label.approval_breakchecks_ny</source>
         <target>Calculate breaktime issues</target>
       </trans-unit>
+      <trans-unit id="Mdn3yh_" resname="label.approval_include_admin_ny">
+        <source>label.approval_include_admin_ny</source>
+        <target>Include approvals for systems administrators</target>
+      </trans-unit>
+      <trans-unit id="9yM8I2U" resname="label.approval_teamlead_selfapprove_ny">
+        <source>label.approval_teamlead_selfapprove_ny</source>
+        <target>Self approve for teamleads</target>
+      </trans-unit>
       <trans-unit id="NUgf0fZ" resname="description.workday_history">
         <source>description.workday_history</source>
         <target>

--- a/Resources/views/report_by_user.html.twig
+++ b/Resources/views/report_by_user.html.twig
@@ -43,7 +43,7 @@
                         <i class="fa fa-1x fa-history"></i>
                     </a>
                 {% endif %}
-                    {% if (status == 'submitted') and not (user.id == currentUser and canManageHimself) %}
+                    {% if (status == 'submitted') and (user.id != currentUser or canManageHimself) %}
                     <a href="{{ path('approve',{'approveId':approveId,'user':user.id,'date':current|date('Y-m-d')}) }}" class="btn btn-default btn-create" title="{{ 'tooltip.approve'|trans }}">
                         <i class="fa fa-1x fa-check-circle"></i>
                     </a>

--- a/Toolbox/SecurityTool.php
+++ b/Toolbox/SecurityTool.php
@@ -14,16 +14,13 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 
-use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
-use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
-
 class SecurityTool
 {
     private ?array $cache = null;
     private ?bool $viewAll = null;
     private ?bool $viewTeam = null;
 
-    public function __construct(private Security $security, private UserRepository $userRepository, private SettingsTool $settingsTool)
+    public function __construct(private Security $security, private UserRepository $userRepository)
     {
     }
 
@@ -89,9 +86,8 @@ class SecurityTool
 
             /** @var array<User> $users */
             $users = array_reduce($users, function ($current, $user) {
-                $includeSuperAdmin = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY) == "1";
                 /** @var User $user */
-                if ($user->isEnabled() && !$user->isSystemAccount() && (!$user->isSuperAdmin() || $includeSuperAdmin )) {
+                if ($user->isEnabled() && !$user->isSystemAccount() && !$user->isSuperAdmin()) {
                     $current[] = $user;
                 }
 

--- a/Toolbox/SecurityTool.php
+++ b/Toolbox/SecurityTool.php
@@ -14,13 +14,16 @@ use App\Entity\User;
 use App\Repository\UserRepository;
 use Symfony\Bundle\SecurityBundle\Security;
 
+use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
+use KimaiPlugin\ApprovalBundle\Enumeration\ConfigEnum;
+
 class SecurityTool
 {
     private ?array $cache = null;
     private ?bool $viewAll = null;
     private ?bool $viewTeam = null;
 
-    public function __construct(private Security $security, private UserRepository $userRepository)
+    public function __construct(private Security $security, private UserRepository $userRepository, private SettingsTool $settingsTool)
     {
     }
 
@@ -86,8 +89,9 @@ class SecurityTool
 
             /** @var array<User> $users */
             $users = array_reduce($users, function ($current, $user) {
+                $includeSuperAdmin = $this->settingsTool->getConfiguration(ConfigEnum::APPROVAL_INCLUDE_ADMIN_NY) == "1";
                 /** @var User $user */
-                if ($user->isEnabled() && !$user->isSystemAccount() && !$user->isSuperAdmin()) {
+                if ($user->isEnabled() && !$user->isSystemAccount() && (!$user->isSuperAdmin() || $includeSuperAdmin )) {
                     $current[] = $user;
                 }
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Kimai plugin to manage approvals and supporting related API",
     "homepage": "https://www.kimai.org/store/katjaglass-approval-bundle.html",
     "type": "kimai-plugin",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "keywords": [
         "kimai",
         "kimai-plugin"


### PR DESCRIPTION
Addresses issue #32 - migration of Teamlead self approve & System-Admin features from v1 branch.

Tested and working well in my environment.

- When team lead self-approve is enabled, the team lead will appear in their own 'To Approve' list, and approval option will appear in the 'Approved weeks report' view.
- When System-Admin approval feature is enabled, System Admins will appear in the 'To Approve' view and in the 'Approved Weeks Report' view.

Feedback gratefully accepted - apologies for the messy commit history, unsure how to resolve but I assume it can be squashed during merge.