### PR TITLE
Remove API security annotation

### DIFF
--- a/API/ApprovalBundleApiController.php
+++ b/API/ApprovalBundleApiController.php
@@ -23,7 +23,6 @@ use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalStatusRepository;
 use KimaiPlugin\ApprovalBundle\Repository\LockdownRepository;
 use KimaiPlugin\ApprovalBundle\Toolbox\EmailTool;
-use Nelmio\ApiDocBundle\Annotation\Security as ApiSecurity;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,8 +52,6 @@ final class ApprovalBundleApiController extends BaseApiController
     #[Rest\QueryParam(name: 'user', requirements: '\d+', strict: true, nullable: true, description: 'User ID to get information for')]
     #[Rest\QueryParam(name: 'date', nullable: false, description: 'Date as monday of selected week: Y-m-d')]
     #[Route(methods: ['POST'], path: '/add_to_approve')]
-    #[ApiSecurity(name: 'apiUser')]
-    #[ApiSecurity(name: 'apiToken')]
     public function submitWeekAction(Request $request): Response
     {
         $selectedUserId = $request->query->get('user');

--- a/API/ApprovalNextWeekApiController.php
+++ b/API/ApprovalNextWeekApiController.php
@@ -15,7 +15,6 @@ use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
-use Nelmio\ApiDocBundle\Annotation\Security as ApiSecurity;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,8 +37,6 @@ final class ApprovalNextWeekApiController extends BaseApiController
     #[OA\Response(response: 200, description: 'Status of selected week')]
     #[Rest\QueryParam(name: 'user', requirements: '\d+', strict: true, nullable: true, description: 'User ID to get information for')]
     #[Route(methods: ['GET'], path: '/next-week')]
-    #[ApiSecurity(name: 'apiUser')]
-    #[ApiSecurity(name: 'apiToken')]
     public function nextWeekAction(Request $request): Response
     {
         $selectedUserId = $request->query->get('user');

--- a/API/ApprovalOvertimeController.php
+++ b/API/ApprovalOvertimeController.php
@@ -17,7 +17,6 @@ use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
 use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
-use Nelmio\ApiDocBundle\Annotation\Security as ApiSecurity;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,8 +41,6 @@ final class ApprovalOvertimeController extends BaseApiController
     #[Rest\QueryParam(name: 'user', requirements: '\d+', strict: true, nullable: true, description: 'User ID to get information for')]
     #[Rest\QueryParam(name: 'date', nullable: false, description: 'Date to get overtime until/including this date: Y-m-d')]
     #[Route(methods: ['GET'], path: '/overtime_year')]
-    #[ApiSecurity(name: 'apiUser')]
-    #[ApiSecurity(name: 'apiToken')]
     public function overtimeForYearUntil(Request $request): Response
     {
         $selectedUserId = $request->query->get('user');

--- a/API/ApprovalOvertimeWeeklyController.php
+++ b/API/ApprovalOvertimeWeeklyController.php
@@ -17,7 +17,6 @@ use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
 use KimaiPlugin\ApprovalBundle\Toolbox\SettingsTool;
-use Nelmio\ApiDocBundle\Annotation\Security as ApiSecurity;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,8 +41,6 @@ final class ApprovalOvertimeWeeklyController extends BaseApiController
     #[Rest\QueryParam(name: 'user', requirements: '\d+', strict: true, nullable: true, description: 'User ID to get information for')]
     #[Rest\QueryParam(name: 'date', nullable: false, description: 'Date to get weekly overtime overview up from this date: Y-m-d')]
     #[Route(methods: ['GET'], path: '/weekly_overtime')]
-    #[ApiSecurity(name: 'apiUser')]
-    #[ApiSecurity(name: 'apiToken')]
     public function weeklyOvertime(Request $request): Response
     {
         $selectedUserId = $request->query->get('user');

--- a/API/ApprovalStatusApiController.php
+++ b/API/ApprovalStatusApiController.php
@@ -18,7 +18,6 @@ use FOS\RestBundle\View\ViewHandlerInterface;
 use KimaiPlugin\ApprovalBundle\Entity\Approval;
 use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
 use KimaiPlugin\ApprovalBundle\Repository\ApprovalRepository;
-use Nelmio\ApiDocBundle\Annotation\Security as ApiSecurity;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,8 +41,6 @@ final class ApprovalStatusApiController extends BaseApiController
     #[Rest\QueryParam(name: 'user', requirements: '\d+', strict: true, nullable: true, description: 'User ID to get information for')]
     #[Rest\QueryParam(name: 'date', nullable: false, description: 'Date as monday of selected week: Y-m-d')]
     #[Route(methods: ['GET'], path: '/week-status')]
-    #[ApiSecurity(name: 'apiUser')]
-    #[ApiSecurity(name: 'apiToken')]
     public function submitWeekAction(Request $request): Response
     {
         $selectedUserId = $request->query->get('user');


### PR DESCRIPTION
The last release of Kimai core introduced API tokens, which improve response speed of the API from 0.7s/call to 0.2s per call,  removing half a second from each API call. 

The new tokens including an example are explained at https://www.kimai.org/documentation/rest-api.html

With that change the security annotation became deprecated, it is not needed anymore and can be removed.

This annotation was just used in the API docs, which now ships a global "Bearer token" configuration.