### PR TITLE
fix deprecation

### DIFF
--- a/DependencyInjection/ApprovalExtension.php
+++ b/DependencyInjection/ApprovalExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class ApprovalExtension extends Extension implements PrependExtensionInterface
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader(
             $container,
@@ -27,7 +27,7 @@ class ApprovalExtension extends Extension implements PrependExtensionInterface
         $loader->load('services.yaml');
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $container->prependExtensionConfig('kimai', [
             'permissions' => [


### PR DESCRIPTION
Fixes the deprecations:
```
User Deprecated: Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "KimaiPlugin\ApprovalBundle\DependencyInjection\ApprovalExtension" now to avoid errors or add an explicit @return annotation to suppress this message. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Method \"Symfony\\Component\\DependencyInjection\\Extension\\ExtensionInterface::load()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"KimaiPlugin\\ApprovalBundle\\DependencyInjection\\ApprovalExtension\" now to avoid errors or add an explicit @return annotation to suppress this message. 
```

and 

```
User Deprecated: Method "Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface::prepend()" might add "void" as a native return type declaration in the future. Do the same in implementation "KimaiPlugin\ApprovalBundle\DependencyInjection\ApprovalExtension" now to avoid errors or add an explicit @return annotation to suppress this message. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Method \"Symfony\\Component\\DependencyInjection\\Extension\\PrependExtensionInterface::prepend()\" might add \"void\" as a native return type declaration in the future. Do the same in implementation \"KimaiPlugin\\ApprovalBundle\\DependencyInjection\\ApprovalExtension\" now to avoid errors or add an explicit @return annotation to suppress this message. 
```