### PR TITLE
Update WeekReportController.php

### DIFF
--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -130,7 +130,7 @@ class WeekReportController extends BaseApprovalController
 
         return $this->render('@Approval/report_by_user.html.twig', [
             'approve' => $this->parseToHistoryView($selectedUser, $startWeek),
-            'week' => $this->formatting->parseDate(new DateTime($startWeek)),
+            'week' => $this->formatting->parseDate($startWeek instanceof DateTime ? $startWeek : new DateTime($startWeek)),
             'box_id' => 'user-week-report-box',
             'form' => $form->createView(),
             'days' => new DailyStatistic($start, $end, $selectedUser),


### PR DESCRIPTION
I encountered a TypeError in the WeekReportController class of the ApprovalBundle package. The error occurs when trying to instantiate a DateTime object using another DateTime instance as an argument.

This is the error:
CRITICAL: Uncaught PHP Exception TypeError: "DateTime::__construct(): Argument https://github.com/KatjaGlassConsulting/ApprovalBundle/issues/1 ($datetime) must be of type string, DateTime given" at WeekReportController.php line 133

The error occurs on the following line of code:
'week' => $this->formatting->parseDate(new DateTime($startWeek)),

If $startWeek is already a DateTime object, passing it again to the DateTime constructor causes an error. This leads to a situation where the application fails to function correctly

It is advisable to check if $startWeek is already a DateTime object before passing it to the constructor. Here’s how the code could be modified:
'week' => $this->formatting->parseDate($startWeek instanceof DateTime ? $startWeek : new DateTime($startWeek)),

I hope this information is helpful for resolving the issue for anyone else who has encountered the same error.

Environment:

PHP Version: 8.3
Symfony Version: 6