### PR TITLE
Filtering and Sorting for to_approve endpoint + hide approvals config + bugfix 

### DIFF
--- a/Controller/WeekReportController.php
+++ b/Controller/WeekReportController.php
@@ -60,7 +60,8 @@ class WeekReportController extends BaseApprovalController
         private ApprovalTimesheetRepository $approvalTimesheetRepository,
         private BreakTimeCheckToolGER $breakTimeCheckToolGER,
         private ReportRepository $reportRepository
-    ) {}
+    ) {
+    }
 
     #[Route(path: '/week_by_user', name: 'approval_bundle_report', methods: ['GET', 'POST'])]
     public function weekByUser(Request $request): Response
@@ -177,6 +178,10 @@ class WeekReportController extends BaseApprovalController
         }
 
         $allRows = $this->approvalRepository->findAllWeek($users);
+
+        if ($this->settingsTool->getBooleanConfiguration(ConfigEnum::APPROVAL_HIDE_APPROVED_NY, false)) {
+            $allRows = $this->approvalRepository->filterWeeksNotApproved($allRows);
+        }
 
         $pastRows = [];
         $currentRows = [];
@@ -301,10 +306,8 @@ class WeekReportController extends BaseApprovalController
             $this->settingsTool->setConfiguration(ConfigEnum::CUSTOMER_FOR_FREE_DAYS, $this->collectCustomerForFreeDays($data));
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_MAIL_SUBMITTED_NY, $data[FormEnum::MAIL_SUBMITTED_NY]);
             $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_MAIL_ACTION_NY, $data[FormEnum::MAIL_ACTION_NY]);
-
-            if (isset($data[FormEnum::EXPECTED_DURATION_NY])) {
-                $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_EXPECTED_DURATION_NY, $data[FormEnum::EXPECTED_DURATION_NY]);
-            }
+            $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_EXPECTED_DURATION_NY, $data[FormEnum::EXPECTED_DURATION_NY]);
+            $this->settingsTool->setConfiguration(ConfigEnum::APPROVAL_HIDE_APPROVED_NY, $data[FormEnum::HIDE_APPROVED_NY]);
 
             $this->flashSuccess('action.update.success');
         }

--- a/Enumeration/ConfigEnum.php
+++ b/Enumeration/ConfigEnum.php
@@ -22,4 +22,5 @@ abstract class ConfigEnum
     public const APPROVAL_MAIL_SUBMITTED_NY = 'approval.mail_submitted_ny';
     public const APPROVAL_MAIL_ACTION_NY = 'approval.mail_action_ny';
     public const APPROVAL_EXPECTED_DURATION_NY = 'approval.expected_duration_ny';
+    public const APPROVAL_HIDE_APPROVED_NY = 'approval.hide_approved_ny';
 }

--- a/Enumeration/FormEnum.php
+++ b/Enumeration/FormEnum.php
@@ -30,5 +30,6 @@ abstract class FormEnum
     public const MAIL_SUBMITTED_NY = 'approval_mail_submitted_ny';
     public const MAIL_ACTION_NY = 'approval_mail_action_ny';
     public const EXPECTED_DURATION_NY = 'approval_expected_duration_ny';
+    public const HIDE_APPROVED_NY = 'approval_hide_approved_ny';
 
 }

--- a/Form/AddToApprove.php
+++ b/Form/AddToApprove.php
@@ -32,11 +32,17 @@ class AddToApprove extends AbstractType
             'width' => false
         ]);
 
+        $choices = [];
+        foreach ($this->approvalRepository->getWeeks($options['user']) as $w) {
+            $w->value = $w->value->format('Y-m-d');
+            $choices[] = $w;
+        }
+
         $builder->add('week', ChoiceType::class, [
             'label' => 'agendaWeek',
             'required' => true,
             'multiple' => true,
-            'choices' => $this->approvalRepository->getWeeks($options['user']),
+            'choices' => $choices,
             'choice_value' => 'value',
             'choice_label' => 'label'
         ]);

--- a/Form/SettingsForm.php
+++ b/Form/SettingsForm.php
@@ -28,7 +28,8 @@ class SettingsForm extends AbstractType
         private readonly FormTool $formTool,
         private readonly SettingsTool $settingsTool,
         private readonly CustomerRepository $customerRepository
-    ) {}
+    ) {
+    }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -107,6 +108,12 @@ class SettingsForm extends AbstractType
         $builder->add(FormEnum::EXPECTED_DURATION_NY, CheckboxType::class, [
             'label' => 'label.approval_expected_duration_ny',
             'data' => $this->settingsTool->getBooleanConfiguration(ConfigEnum::APPROVAL_EXPECTED_DURATION_NY, true),
+            'required' => false
+        ]);
+
+        $builder->add(FormEnum::HIDE_APPROVED_NY, CheckboxType::class, [
+            'label' => 'label.approval_hide_approved_ny',
+            'data' => $this->settingsTool->getBooleanConfiguration(ConfigEnum::APPROVAL_HIDE_APPROVED_NY, false),
             'required' => false
         ]);
 

--- a/Form/Toolbar/ApprovalToolbarForm.php
+++ b/Form/Toolbar/ApprovalToolbarForm.php
@@ -1,0 +1,54 @@
+<?php
+namespace KimaiPlugin\ApprovalBundle\Form\Toolbar;
+
+use App\Form\Toolbar\ToolbarFormTrait;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use KimaiPlugin\ApprovalBundle\Entity\ApprovalStatus;
+use KimaiPlugin\ApprovalBundle\Repository\Query\ApprovalQuery;
+
+final class ApprovalToolbarForm extends AbstractType
+{
+    use ToolbarFormTrait;
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $this->addSearchTermInputField($builder);
+
+        $this->addDateRange($builder, ['timezone' => $options['timezone']]);
+
+        $this->addUsersChoice($builder);
+
+        $builder->add('status', ChoiceType::class, [
+            'required' => false,
+            'placeholder' => 'All',
+            'choices' => [
+                ApprovalStatus::SUBMITTED => ApprovalStatus::SUBMITTED,
+                ApprovalStatus::DENIED => ApprovalStatus::DENIED,
+                ApprovalStatus::APPROVED => ApprovalStatus::APPROVED,
+                ApprovalStatus::NOT_SUBMITTED => ApprovalStatus::NOT_SUBMITTED,
+            ],
+            'multiple' => true,
+        ]);
+
+        $this->addHiddenPagination($builder);
+
+        $query = $options['data'];
+
+        if ($query instanceof ApprovalQuery) {
+            $this->addOrder($builder);
+            $this->addOrderBy($builder, $query->getAllowedOrderColumns());
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ApprovalQuery::class,
+            'csrf_protection' => false,
+            'timezone' => date_default_timezone_get(),
+        ]);
+    }
+}

--- a/Repository/ApprovalRepository.php
+++ b/Repository/ApprovalRepository.php
@@ -150,14 +150,14 @@ class ApprovalRepository extends ServiceEntityRepository
 
         $overtimeFormatted = $this->formatting->formatDuration($overtime);
         $result =
-        [
-            'expectedDuration' => $expectedDuration,
-            'actualDuration' => $actualDuration,
-            'overtime' => $overtime,
-            'overtimeFormatted' => $overtimeFormatted,
-            'manualAdoption' => $manualAdoption,
-            'endDay' => $endDate->format('Y-m-d')
-        ];
+            [
+                'expectedDuration' => $expectedDuration,
+                'actualDuration' => $actualDuration,
+                'overtime' => $overtime,
+                'overtimeFormatted' => $overtimeFormatted,
+                'manualAdoption' => $manualAdoption,
+                'endDay' => $endDate->format('Y-m-d')
+            ];
 
         return $result;
     }
@@ -469,7 +469,7 @@ class ApprovalRepository extends ServiceEntityRepository
         } else {
             $weekString = $week;
         }
-        
+
         $em = $this->getEntityManager();
 
         return $em->createQueryBuilder()
@@ -628,6 +628,13 @@ class ApprovalRepository extends ServiceEntityRepository
             },
             []
         );
+    }
+
+    public function filterWeeksNotApproved(array $parseToViewArray): array
+    {
+        return array_values(array_filter($parseToViewArray, function ($approve) {
+            return $approve['status'] !== ApprovalStatus::APPROVED;
+        }));
     }
 
     public function filterWeeksNotSubmitted($parseToViewArray): array

--- a/Repository/ApprovalRepository.php
+++ b/Repository/ApprovalRepository.php
@@ -332,7 +332,10 @@ class ApprovalRepository extends ServiceEntityRepository
                         'expectedDuration' => $item->getExpectedDuration(),
                         'actualDuration' => $item->getActualDuration(),
                         'user' => $item->getUser()->getDisplayName(),
-                        'week' => $this->formatting->parseDate(clone $item->getStartDate()),
+                        'week' => (object) [
+                            'label' => $this->formatting->parseDate(clone $item->getStartDate()),
+                            'value' => (clone $item->getStartDate()),
+                        ],
                         'status' => $item->getHistory()[0]->getStatus()->getName()
                     ];
             }
@@ -380,14 +383,13 @@ class ApprovalRepository extends ServiceEntityRepository
             if (!\in_array($firstDay, $approvedWeeks) && $firstDay->format('Y-m-d') > $approval_ws_start_week) {
                 $weeks[] = (object) [
                     'label' => $this->formatting->parseDate($firstDay),
-                    'value' => (clone $firstDay)->format('Y-m-d')
+                    'value' => (clone $firstDay)
                 ];
             }
             $firstDay->modify('next monday');
         }
 
         array_pop($weeks);
-
         return $weeks;
     }
 
@@ -446,19 +448,18 @@ class ApprovalRepository extends ServiceEntityRepository
         foreach ($users as $user) {
             $weeks = $this->getWeeks($user);
             foreach ($weeks as $week) {
-                if (!\in_array($user->getId() . '-' . $week->value, $usedUsersWeeks)) {
+                if (!\in_array($user->getId() . '-' . $week->value->format('Y-m-d'), $usedUsersWeeks)) {
                     $parseToViewArray[] =
                         [
                             'userId' => $user->getId(),
-                            'startDate' => $week->value,
+                            'startDate' => $week->value->format('Y-m-d'),
                             'user' => $user->getDisplayName(),
-                            'week' => $week->label,
+                            'week' => $week,
                             'status' => ApprovalStatus::NOT_SUBMITTED
                         ];
                 }
             }
         }
-
         return $parseToViewArray;
     }
 

--- a/Repository/Query/ApprovalQuery.php
+++ b/Repository/Query/ApprovalQuery.php
@@ -1,0 +1,48 @@
+<?php
+namespace KimaiPlugin\ApprovalBundle\Repository\Query;
+
+use App\Entity\User;
+use App\Repository\Query\BaseQuery;
+use App\Repository\Query\DateRangeTrait;
+use App\Repository\Query\DateRangeInterface;
+
+class ApprovalQuery extends BaseQuery implements DateRangeInterface
+{
+    use DateRangeTrait;
+    public const APPROVAL_ORDER_ALLOWED = ['user', 'week', 'status'];
+
+    /**
+     * @var array<User>
+     */
+    public array $users = [];
+    private array $weeks = [];
+    private array $statuses = [];
+
+    public function __construct()
+    {
+        $this->setDefaults([
+            'order' => self::ORDER_ASC,
+            'orderBy' => 'week',
+        ]);
+
+        $this->setAllowedOrderColumns(self::APPROVAL_ORDER_ALLOWED);
+    }
+
+    public function getStatus(): array
+    {
+        return $this->statuses;
+    }
+
+    public function setStatus(array $statuses): void
+    {
+        $this->statuses = $statuses;
+    }
+
+    /**
+     * @return User[]
+     */
+    public function getUsers(): array
+    {
+        return array_values($this->users);
+    }
+}

--- a/Resources/translations/messages.de.xlf
+++ b/Resources/translations/messages.de.xlf
@@ -424,6 +424,10 @@
         <source>label.approval_expected_duration_ny</source>
         <target>Erwartete Dauer anzeigen</target>
       </trans-unit>
+      <trans-unit id="hJkL2mN" resname="label.approval_hide_approved_ny">
+        <source>label.approval_hide_approved_ny</source>
+        <target>Genehmigte Freigaben ausblenden</target>
+      </trans-unit>
       <trans-unit id="NUgf0fZ" resname="description.workday_history">
         <source>description.workday_history</source>
         <target>

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -424,6 +424,10 @@
         <source>label.approval_expected_duration_ny</source>
         <target>Show expected duration</target>
       </trans-unit>
+      <trans-unit id="hJkL2mN" resname="label.approval_hide_approved_ny">
+        <source>label.approval_hide_approved_ny</source>
+        <target>Hide approved approvals</target>
+      </trans-unit>
       <trans-unit id="NUgf0fZ" resname="description.workday_history">
         <source>description.workday_history</source>
         <target>

--- a/Resources/translations/messages.hr.xlf
+++ b/Resources/translations/messages.hr.xlf
@@ -416,6 +416,10 @@
         <source>label.approval_expected_duration_ny</source>
         <target>Prikaži očekivano trajanje</target>
       </trans-unit>
+      <trans-unit id="hJkL2mN" resname="label.approval_hide_approved_ny">
+        <source>label.approval_hide_approved_ny</source>
+        <target>Sakrij odobrena odobrenja</target>
+      </trans-unit>
       <trans-unit id="NUgf0fZ" resname="description.workday_history">
         <source>description.workday_history</source>
         <target>

--- a/Resources/views/to_approve.html.twig
+++ b/Resources/views/to_approve.html.twig
@@ -1,88 +1,130 @@
 {% extends '@Approval/layout.html.twig' %}
 {% from '@Approval/macros.html.twig' import status_color_class %}
+{% import "macros/datatables.html.twig" as tables %}
 
 {% block report_title %}{{ report_title|trans }}{% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <style>
+        tr.table-section-header td {
+            font-weight: bold;
+            padding: 15px 10px;
+        }
+
+        tr.table-section-header h3 {
+            margin: 0;
+        }
+    </style>
+{% endblock %}
+
 {% block report %}
+    {{ tables.actions(all_rows_datatable) }}
+    {{ tables.header(all_rows_datatable) }}
+
+    {% set sortedColumns = all_rows_datatable.sortedColumnNames %}
+
     {% if past_rows is not empty %}
-        <h3 class="mt-4 ps-3">{{ 'table.past_weeks'|trans }}</h3>
-
-        <table class="table table-vcenter table-hover dataTable">
-            <thead>
-            <tr>
-                <th>{{ 'table.approve_user'|trans }}</th>
-                <th>{{ 'table.approve_week'|trans }}</th>
-                <th>{{ 'table.approve_status'|trans }}</th>
-                <th class="actions"></th>
-            </tr>
-
-            {% for row in past_rows %}
-                <tr class="{{ status_color_class(row['status']) }}">
-                    <td>{{ row['user'] }}</td>
-                    <td>{{ row['week'] }}</td>
-                    <td>{{ row['status']|trans }}</td>
-                    <td class="actions">
-                        <a class="btn btn-default" style="font-weight: bold;"
-                           href="{{ path('approval_bundle_report', {'user':row['userId'], 'date': row['startDate']}) }}">
-                            <i class="fas fa-1x fa-eye"></i>
-                        </a>
-                    </td>
-                </tr>
-            {% endfor %}
-            </thead>
-        </table>
-    {% endif %}
-
-    <h3 class="mt-4 ps-3">{{ 'table.current_week'|trans }}</h3>
-
-    <table class="table table-vcenter table-hover dataTable">
-        <thead>
-        <tr>
-            <th>{{ 'table.approve_user'|trans }}</th>
-            <th>{{ 'table.approve_week'|trans }}</th>
-            <th>{{ 'table.approve_status'|trans }}</th>
-            <th class="actions"></th>
+        <tr class="table-section-header">
+            <td colspan="{{ sortedColumns|length }}">
+                <h3>{{ 'table.past_weeks'|trans }}</h3>
+            </td>
         </tr>
-        {% for row in current_rows %}
-            <tr class="{{ status_color_class(row['status']) }}">
-                <td>{{ row['user'] }}</td>
-                <td>{{ row['week'] }}</td>
-                <td>{{ row['status']|trans }}</td>
-                <td class="actions">
-                    <a class="btn btn-default" style="font-weight: bold;"
-                       href="{{ path('approval_bundle_report', {'user':row['userId'], 'date': row['startDate']}) }}">
-                        <i class="fas fa-eye"></i>
-                    </a>
-                </td>
-            </tr>
+        {% for entry in past_rows %}
+            {{ block('datatable_row') }}
         {% endfor %}
-        </thead>
-    </table>
-
-    {% if future_rows is not empty %}                                
-        <h3 class="mt-4 ps-3">{{ 'table.future_week'|trans }}</h3>
-        <table class="table table-vcenter table-hover dataTable">
-            <thead>
-            <tr>
-                <th>{{ 'table.approve_user'|trans }}</th>
-                <th>{{ 'table.approve_week'|trans }}</th>
-                <th>{{ 'table.approve_status'|trans }}</th>
-                <th class="actions"></th>
-            </tr>
-            {% for row in future_rows %}
-                <tr class="{{ status_color_class(row['status']) }}">
-                    <td>{{ row['user'] }}</td>
-                    <td>{{ row['week'] }}</td>
-                    <td>{{ row['status']|trans }}</td>
-                    <td class="actions">
-                        <a class="btn btn-default" style="font-weight: bold;"
-                          href="{{ path('approval_bundle_report', {'user':row['userId'], 'date': row['startDate']}) }}">
-                            <i class="fas fa-eye"></i>
-                        </a>
-                    </td>
-                </tr>
-            {% endfor %}
-            </thead>
-        </table>
     {% endif %}
+
+    {% if current_rows is not empty %}
+        <tr class="table-section-header">
+            <td colspan="{{ sortedColumns|length }}">
+                <h3>{{ 'table.current_week'|trans }}</h3>
+            </td>
+        </tr>
+        {% for entry in current_rows %}
+            {{ block('datatable_row') }}
+        {% endfor %}
+    {% endif %}
+
+    {% if future_rows is not empty %}
+        <tr class="table-section-header">
+            <td colspan="{{ sortedColumns|length }}">
+                <h3>{{ 'table.future_week'|trans }}</h3>
+            </td>
+        </tr>
+        {% for entry in future_rows %}
+            {{ block('datatable_row') }}
+        {% endfor %}
+    {% endif %}
+
+    {{ tables.footer(all_rows_datatable) }}
+{% endblock %}
+
+{% block datatable_row %}
+    <tr class="{{ status_color_class(entry['status']) }}">
+        {% for column, data in sortedColumns %}
+            {{ block('datatable_column') }}
+        {% endfor %}
+    </tr>
+{% endblock %}
+
+{% block datatable_column %}
+    <td class="{{ tables.class(all_rows_datatable, column) }}">
+    {% if column == 'user' %}
+        {{ entry['user'] }}
+    {% elseif column == 'week' %}
+        {{ entry['week'].label }}
+    {% elseif column == 'status' %}
+        {{ entry['status']|trans }}
+    {% elseif column == 'actions' %}
+        <a class="btn btn-default" style="font-weight: bold;"
+            href="{{ path('approval_bundle_report', {'user':entry['userId'], 'date': entry['startDate']}) }}">
+                <i class="fas fa-1x fa-eye"></i>
+        </a>
+    {% endif %}
+    </td>
+{% endblock %}
+
+{% block javascripts %}
+   {{ parent() }}
+    <script>
+        let kimaiInstance = null;
+        
+        document.addEventListener('kimai.initialized', function(e) {
+            kimaiInstance = e.detail.kimai;
+        });
+    
+        document.addEventListener('kimai.reloadedContent', function() {
+            if (kimaiInstance) {
+                const formSelectPlugin = kimaiInstance.getPlugin('form-select');
+                const searchForm = document.querySelector('form.searchform');
+                
+                if (formSelectPlugin && searchForm) {
+                    formSelectPlugin.activateForm(searchForm);
+                }
+            }
+        });
+
+        // Override Kimai's default DESC sorting behavior
+        document.body.addEventListener('click', (event) => {
+            if (!event.target.matches('th.sortable')) {
+                return;
+            }
+            const isSorted = event.target.classList.contains('sorting_asc') || 
+                           event.target.classList.contains('sorting_desc');
+            if (!isSorted) {
+                event.stopImmediatePropagation();
+                
+                const orderBy = event.target.dataset['order'];
+                const formSelector = 'form.searchform';
+                
+                document.querySelector(formSelector + ' #orderBy').value = orderBy;
+                document.querySelector(formSelector + ' #order').value = 'ASC';
+                
+                document.querySelector(formSelector + ' #orderBy').dispatchEvent(new Event('change'));
+                document.querySelector(formSelector + ' #order').dispatchEvent(new Event('change'));
+                document.dispatchEvent(new Event('filter-change'));
+            }
+        }, true);
+    </script>
 {% endblock %}

--- a/Toolbox/BreakTimeCheckToolGER.php
+++ b/Toolbox/BreakTimeCheckToolGER.php
@@ -58,9 +58,11 @@ class BreakTimeCheckToolGER
     private function checkOffdayWork($timesheets, &$errors, $offdays)
     {
         foreach ($timesheets as $timesheet) {
-            if (\in_array($timesheet->getBegin()->format('Y-m-d'), $offdays) &&
-                  ($errors[$timesheet->getBegin()->format('Y-m-d')] == null ||
-                   \in_array($this->translator->trans('error.work_offdays'), $errors[$timesheet->getBegin()->format('Y-m-d')]) == false)) {
+            if (
+                \in_array($timesheet->getBegin()->format('Y-m-d'), $offdays) &&
+                ($errors[$timesheet->getBegin()->format('Y-m-d')] == null ||
+                    \in_array($this->translator->trans('error.work_offdays'), $errors[$timesheet->getBegin()->format('Y-m-d')]) == false)
+            ) {
                 $errors[$timesheet->getBegin()->format('Y-m-d')][] = $this->translator->trans('error.work_offdays');
             }
         }
@@ -84,7 +86,7 @@ class BreakTimeCheckToolGER
         $blockStart = 0;
         $blockEnd = 0;
         foreach ($timesheets as $timesheet) {
-            if($timesheet->getEnd() == null) {
+            if ($timesheet->getEnd() == null) {
                 continue;
             }
 
@@ -99,8 +101,10 @@ class BreakTimeCheckToolGER
             }
             $blockEnd = $timesheet->getEnd()->getTimestamp();
             if ($blockEnd - $blockStart > $sixHoursInSeconds) {
-                if ($errors[$timesheet->getBegin()->format('Y-m-d')] == null ||
-                        \in_array($this->translator->trans('error.six_hours_without_stop_break'), $errors[$timesheet->getBegin()->format('Y-m-d')]) == false) {
+                if (
+                    array_key_exists($timesheet->getBegin()->format('Y-m-d'), $errors) && ($errors[$timesheet->getBegin()->format('Y-m-d')] == null ||
+                        \in_array($this->translator->trans('error.six_hours_without_stop_break'), $errors[$timesheet->getBegin()->format('Y-m-d')]) == false)
+                ) {
                     $errors[$timesheet->getBegin()->format('Y-m-d')][] = $this->translator->trans('error.six_hours_without_stop_break');
                 }
             }


### PR DESCRIPTION
Hey,

i got a warning, when i used break time issues, with the kimai/kimai2:dev image.

This commit checks, if the errors array has a key, in line 105:
```
array_key_exists($timesheet->getBegin()->format('Y-m-d'), $errors) && ( ...
```

It prevents this warning:
<img width="1258" height="723" alt="image" src="https://github.com/user-attachments/assets/acb58b5a-7777-429f-8efa-b03601cd7068" />

I got this warning for example if "Customer for free days" was empty, and "Calculate breaktime issues" was checked.

<img width="1282" height="393" alt="image" src="https://github.com/user-attachments/assets/f8a3575d-a784-4b25-aaf4-16a6cb00b5c8" />

Thank you



 